### PR TITLE
Use keyword list opts instead of default args.

### DIFF
--- a/lib/ex_aws/rekognition.ex
+++ b/lib/ex_aws/rekognition.ex
@@ -455,9 +455,14 @@ defmodule ExAws.Rekognition do
     S3Object.map(object)
   end
 
+  # NOTE: Does not preserve order, unlike the name "map" might imply
+  defp kw_map(kwl, keys, fun) do
+    {split_kws, kws} = Keyword.split(kwl, keys)
+    kws ++ Enum.map(split_kws, fun)
+  end
+
   defp stringify_enum_opts(opts, keys) do
-    {enum_opts, opts} = Keyword.split(opts, keys)
-    opts ++ Enum.map(enum_opts, fn {k, v} -> {k, stringify_enum(v)} end)
+    kw_map(opts, keys, &stringify_enum/1)
   end
 
   defp stringify_enum(value) do
@@ -465,11 +470,7 @@ defmodule ExAws.Rekognition do
   end
 
   defp map_notification_channel(opts) do
-    if value = opts[:notification_channel] do
-      Keyword.replace!(opts, :notification_channel, NotificationChannelObject.map(value))
-    else
-      opts
-    end
+    kw_map(opts, [:notification_channel], &NotificationChannelObject.map/1)
   end
 
   defp request(action, data) do

--- a/lib/ex_aws/rekognition.ex
+++ b/lib/ex_aws/rekognition.ex
@@ -455,14 +455,9 @@ defmodule ExAws.Rekognition do
     S3Object.map(object)
   end
 
-  # NOTE: Does not preserve order, unlike the name "map" might imply
-  defp kw_map(kwl, keys, fun) do
-    {split_kws, kws} = Keyword.split(kwl, keys)
-    kws ++ Enum.map(split_kws, fun)
-  end
-
   defp stringify_enum_opts(opts, keys) do
-    kw_map(opts, keys, &stringify_enum/1)
+    {enum_opts, opts} = Keyword.split(opts, keys)
+    opts ++ Enum.map(enum_opts, fn {k, v} -> {k, stringify_enum(v)} end)
   end
 
   defp stringify_enum(value) do
@@ -470,7 +465,11 @@ defmodule ExAws.Rekognition do
   end
 
   defp map_notification_channel(opts) do
-    kw_map(opts, [:notification_channel], &NotificationChannelObject.map/1)
+    if value = opts[:notification_channel] do
+      Keyword.replace!(opts, :notification_channel, NotificationChannelObject.map(value))
+    else
+      opts
+    end
   end
 
   defp request(action, data) do

--- a/test/ex_aws/rekognition_test.exs
+++ b/test/ex_aws/rekognition_test.exs
@@ -29,7 +29,7 @@ defmodule ExAws.RekognitionTest do
              ExAws.Rekognition.compare_faces(
                source_image_binary,
                target_image_binary,
-               similarity_threshold
+               similarity_threshold: similarity_threshold
              )
              |> ExAws.request()
   end


### PR DESCRIPTION
Hello, 

I'd like to present a possibly controversial proposal, not the least due to this being a backwards incompatible change:

Instead of defining optional arguments using defaults, and so having to duplicate the default values used by the AWS API, use a keyword list of options where applicable. It makes it easier to override specific options without having to then provide all the preceding ones also. This is also in line with "Contributing" from ExAws, and follows suit with the existing clients. It is also common in Elixir in general.